### PR TITLE
feat: add REST server streaming support (#347)

### DIFF
--- a/src/ApiException.php
+++ b/src/ApiException.php
@@ -34,6 +34,7 @@ namespace Google\ApiCore;
 use Exception;
 use Google\Protobuf\Internal\RepeatedField;
 use Google\Rpc\Status;
+use GuzzleHttp\Exception\RequestException;
 
 /**
  * Represents an exception thrown during an RPC.
@@ -155,6 +156,39 @@ class ApiException extends Exception
             $status->getDetails(),
             Serializer::decodeAnyMessages($status->getDetails())
         );
+    }
+
+    /**
+     * Creates an ApiException from a GuzzleHttp RequestException.
+     *
+     * @param RequestException $ex
+     * @param boolean $isStream
+     * @return ApiException
+     * @throws ValidationException
+     */
+    public static function createFromRequestException(RequestException $ex, $isStream = false)
+    {
+        $res = $ex->getResponse();
+        $body = (string) $res->getBody();
+        $decoded = json_decode($body, true);
+        
+        // A streaming response body will return one error in an array. Parse
+        // that first (and only) error message, if provided.
+        if ($isStream && isset($decoded[0])) {
+            $decoded = $decoded[0];
+        }
+
+        if ($error = $decoded['error']) {
+            $basicMessage = $error['message'];
+            $code = isset($error['status'])
+                ? ApiStatus::rpcCodeFromStatus($error['status'])
+                : $ex->getCode();
+            $metadata = isset($error['details']) ? $error['details'] : null;
+            return static::createFromApiResponse($basicMessage, $code, $metadata);
+        }
+        // Use the RPC code instead of the HTTP Status Code.
+        $code = ApiStatus::rpcCodeFromHttpStatusCode($res->getStatusCode());
+        return static::createFromApiResponse($body, $code);
     }
 
     /**

--- a/src/ServerStream.php
+++ b/src/ServerStream.php
@@ -34,7 +34,7 @@ namespace Google\ApiCore;
 use Google\Rpc\Code;
 
 /**
- * ServerStream is the response object from a gRPC server streaming API call.
+ * ServerStream is the response object from a server streaming API call.
  */
 class ServerStream
 {
@@ -44,7 +44,7 @@ class ServerStream
     /**
      * ServerStream constructor.
      *
-     * @param \Grpc\ServerStreamingCall $serverStreamingCall The gRPC server streaming call object
+     * @param ServerStreamingCallInterface $serverStreamingCall The server streaming call object
      * @param array $streamingDescriptor
      */
     public function __construct($serverStreamingCall, array $streamingDescriptor = [])
@@ -77,15 +77,15 @@ class ServerStream
             }
         }
         $status = $this->call->getStatus();
-        if (!($status->code == Code::OK)) {
-            throw ApiException::createFromStdClass($status);
+        if ($status->getCode() !== Code::OK) {
+            throw ApiException::createFromRpcStatus($status);
         }
     }
 
     /**
-     * Return the underlying gRPC call object
+     * Return the underlying call object.
      *
-     * @return \Grpc\ServerStreamingCall|mixed
+     * @return ServerStreamingCallInterface
      */
     public function getServerStreamingCall()
     {

--- a/src/ServerStreamingCallInterface.php
+++ b/src/ServerStreamingCallInterface.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2016 Google LLC
+ * Copyright 2021 Google LLC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,20 +30,58 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace Google\ApiCore\Testing;
+namespace Google\ApiCore;
 
-use Google\Rpc\Code;
-
-class MockStatus
+interface ServerStreamingCallInterface
 {
-    /** @var Code $code */
-    public $code;
-    public $details;
-    public $metadata;
-    public function __construct($code, $details = null, array $metadata = [])
-    {
-        $this->code = $code;
-        $this->details = $details;
-        $this->metadata = $metadata;
-    }
+
+    /**
+     * Start the call.
+     *
+     * @param mixed $data     The data to send
+     * @param array $metadata Metadata to send with the call, if applicable
+     *                        (optional)
+     * @param array $options  An array of options, possible keys:
+     *                        'flags' => a number (optional)
+     */
+    public function start($data, array $metadata = [], array $options = []);
+
+    /**
+     * @return mixed An iterator of response values.
+     */
+    public function responses();
+
+    /**
+     * Return the status of the server stream.
+     *
+     * @return \Google\Rpc\Status The API status.
+     */
+    public function getStatus();
+
+    /**
+     * @return mixed The metadata sent by the server.
+     */
+    public function getMetadata();
+
+    /**
+     * @return mixed The trailing metadata sent by the server.
+     */
+    public function getTrailingMetadata();
+
+    /**
+     * @return string The URI of the endpoint.
+     */
+    public function getPeer();
+
+    /**
+     * Cancels the call.
+     */
+    public function cancel();
+
+    /**
+     * Set the CallCredentials for the underlying Call.
+     *
+     * @param mixed $call_credentials The CallCredentials object
+     */
+    public function setCallCredentials($call_credentials);
 }

--- a/src/Testing/MockServerStreamingCall.php
+++ b/src/Testing/MockServerStreamingCall.php
@@ -35,6 +35,7 @@ namespace Google\ApiCore\Testing;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\ApiStatus;
 use Google\Rpc\Code;
+use Google\Rpc\Status;
 
 /**
  * The MockServerStreamingCall class is used to mock out the \Grpc\ServerStreamingCall class
@@ -58,7 +59,7 @@ class MockServerStreamingCall extends \Grpc\ServerStreamingCall
         $this->responses = $responses;
         $this->deserialize = $deserialize;
         if (is_null($status)) {
-            $status = new MockStatus(Code::OK);
+            $status = new MockStatus(Code::OK, 'OK', []);
         }
         $this->status = $status;
     }
@@ -73,7 +74,7 @@ class MockServerStreamingCall extends \Grpc\ServerStreamingCall
     }
 
     /**
-     * @return MockStatus|null|\stdClass
+     * @return \Google\Rpc\Status
      * @throws ApiException
      */
     public function getStatus()
@@ -85,6 +86,12 @@ class MockServerStreamingCall extends \Grpc\ServerStreamingCall
                 ApiStatus::INTERNAL
             );
         }
-        return $this->status;
+        return new Status(
+            [
+                'code' => $this->status->code,
+                'message' => $this->status->details,
+                'details' => $this->status->metadata
+            ]
+        );
     }
 }

--- a/src/Transport/Grpc/ServerStreamingCallWrapper.php
+++ b/src/Transport/Grpc/ServerStreamingCallWrapper.php
@@ -1,0 +1,132 @@
+<?php
+/*
+ * Copyright 2021 Google LLC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Google\ApiCore\Transport\Grpc;
+
+use Google\ApiCore\Serializer;
+use Google\ApiCore\ServerStreamingCallInterface;
+use Google\Rpc\Code;
+use Google\Rpc\Status;
+use Grpc\ServerStreamingCall;
+
+/**
+ * Class ServerStreamingCallWrapper implements \Google\ApiCore\ServerStreamingCallInterface.
+ * This is essentially a wrapper class around the \Grpc\ServerStreamingCall.
+ */
+class ServerStreamingCallWrapper implements ServerStreamingCallInterface
+{
+    private $stream;
+
+    public function __construct(ServerStreamingCall $stream)
+    {
+        $this->stream = $stream;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function start($data, array $metadata = [], array $callOptions = [])
+    {
+        $this->stream->start($data, $metadata, $callOptions);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function responses()
+    {
+        foreach ($this->stream->responses() as $response) {
+            yield $response;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStatus()
+    {
+        // Convert the \stdClass from the Grpc\ServerStreamingCall into a \Google\Rpc\Status.
+        $st = $this->stream->getStatus();
+        $code = property_exists($st, 'code') ? $st->code : Code::OK;
+        return new Status(
+            [
+                'code' => $code,
+                // Field 'details' is actually a string in this \stdClass.
+                'message' => property_exists($st, 'details') ? $st->details : '',
+                // Field 'metadata' is actually an array of objects in this \stdClass.
+                'details' => property_exists($st, 'metadata') && $code !== Code::OK
+                    ? Serializer::decodeMetadata($st->metadata)
+                    : []
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadata()
+    {
+        return $this->stream->getMetadata();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTrailingMetadata()
+    {
+        return $this->stream->getTrailingMetadata();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPeer()
+    {
+        return $this->stream->getPeer();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function cancel()
+    {
+        $this->stream->cancel();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCallCredentials($call_credentials)
+    {
+        $this->stream->setCallCredentials($call_credentials);
+    }
+}

--- a/src/Transport/Rest/JsonStreamDecoder.php
+++ b/src/Transport/Rest/JsonStreamDecoder.php
@@ -33,11 +33,13 @@
 namespace Google\ApiCore\Transport\Rest;
 
 use Psr\Http\Message\StreamInterface;
+use RuntimeException;
 
 class JsonStreamDecoder
 {
     const ESCAPE_CHAR = '\\';
     private $stream;
+    private $closeCalled = false;
     private $decodeType;
     private $ignoreUnknown = true;
     private $readChunkSize = 1024;
@@ -83,10 +85,30 @@ class JsonStreamDecoder
      * completes. Throws an Exception if the stream is closed before the closing
      * byte is read or if it encounters an error while decoding a message.
      *
-     * @throws Exception
+     * @throws RuntimeException
      * @return \Generator
      */
     public function decode()
+    {
+        try {
+            foreach ($this->_decode() as $response) {
+                yield $response;
+            }
+        } catch (RuntimeException $re) {
+            $msg = $re->getMessage();
+            $streamClosedException =
+                strpos($msg, 'Stream is detached') !== false ||
+                strpos($msg, 'Unexpected stream close') !== false;
+            
+            // Only throw the exception if close() was not called and it was not
+            // a closing-related exception.
+            if (!$this->closeCalled || !$streamClosedException) {
+                throw $re;
+            }
+        }
+    }
+
+    private function _decode()
     {
         $decodeType = $this->decodeType;
         $str = false;
@@ -115,6 +137,11 @@ class JsonStreamDecoder
                     $str = !$str;
                 }
 
+                // Skip over new lines that break up items.
+                if ($b === "\n" && $level === 1) {
+                    $start++;
+                }
+
                 // Ignore commas separating messages in the stream array.
                 if ($b === ',' && $level === 1) {
                     $start++;
@@ -129,12 +156,20 @@ class JsonStreamDecoder
                         $start++;
                     }
                 }
-                // Track the closing of an array or object if not in a string
-                // value.
-                if (($b === '}' || $b === ']') && !$str) {
+                // Track the closing of an object if not in a string value.
+                if ($b === '}' && !$str) {
                     $level--;
                     if ($level === 1) {
                         $end = $cursor+1;
+                    }
+                }
+                // Track the closing of an array if not in a string value.
+                if ($b === ']' && !$str) {
+                    $level--;
+                    // If we are seeing a closing square bracket at the
+                    // response message level, e.g. {"foo], there is a problem.
+                    if ($level === 1) {
+                        throw new \RuntimeException('Received closing byte mid-message');
                     }
                 }
 
@@ -180,7 +215,17 @@ class JsonStreamDecoder
             }
         }
         if ($level > 0) {
-            throw new \Exception('Unexpected stream close before receiving the closing byte');
+            throw new \RuntimeException('Unexpected stream close before receiving the closing byte');
         }
+    }
+
+    /**
+     * Closes the underlying stream. If the stream is actively being decoded, an
+     * exception will not be thrown due to the interruption.
+     */
+    public function close()
+    {
+        $this->closeCalled = true;
+        $this->stream->close();
     }
 }

--- a/src/Transport/Rest/RestServerStreamingCall.php
+++ b/src/Transport/Rest/RestServerStreamingCall.php
@@ -1,0 +1,182 @@
+<?php
+/*
+ * Copyright 2021 Google LLC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Google\ApiCore\Transport\Rest;
+
+use Google\ApiCore\ApiException;
+use Google\ApiCore\ApiStatus;
+use Google\ApiCore\ServerStreamingCallInterface;
+use Google\Rpc\Code;
+use Google\Rpc\Status;
+use GuzzleHttp\Exception\RequestException;
+
+/**
+ * Class RestServerStreamingCall implements \Google\ApiCore\ServerStreamingCallInterface.
+ *
+ * @experimental
+ */
+class RestServerStreamingCall implements ServerStreamingCallInterface
+{
+    private $httpHandler;
+    private $originalRequest;
+    private $decoder;
+    private $decodeType;
+    private $decoderOptions;
+    private $response;
+    private $status;
+
+    public function __construct($httpHandler, $decodeType, array $decoderOptions)
+    {
+        $this->httpHandler = $httpHandler;
+        $this->decodeType = $decodeType;
+        $this->decoderOptions = $decoderOptions;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function start($request, array $headers = [], array $callOptions = [])
+    {
+        $this->originalRequest = $this->appendHeaders($request, $headers);
+        
+        try {
+            $handler = $this->httpHandler;
+            $response = $handler(
+                $this->originalRequest,
+                $callOptions
+            )->wait();
+        } catch (\Exception $ex) {
+            if ($ex instanceof RequestException && $ex->hasResponse()) {
+                $ex = ApiException::createFromRequestException($ex, /* isStream */ true);
+            }
+            throw $ex;
+        }
+
+        // Create an OK Status for a successful request just so that it
+        // has a return value.
+        $this->status = new Status(
+            [
+                'code' => Code::OK,
+                'message' => ApiStatus::OK,
+                'details' => []
+            ]
+        );
+        $this->response = $response;
+    }
+
+    private function appendHeaders($request, $headers)
+    {
+        foreach ($headers as $key => $value) {
+            $request = $request->hasHeader($key) ?
+                        $request->withAddedHeader($key, $value) :
+                        $request->withHeader($key, $value);
+        }
+
+        return $request;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function responses()
+    {
+        if (is_null($this->response)) {
+            throw new \Exception('Stream has not been started.');
+        }
+
+        // Decode the stream and yield responses as they are read.
+        $this->decoder = new JsonStreamDecoder(
+            $this->response->getBody(),
+            $this->decodeType,
+            $this->decoderOptions
+        );
+
+        foreach ($this->decoder->decode() as $message) {
+            yield $message;
+        }
+    }
+
+    /**
+     * Return the status of the server stream. If the call has not been started
+     * this will be null.
+     *
+     * @return \Google\Rpc\Status The status, with integer $code, string
+     *                   $details, and array $metadata members
+     */
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadata()
+    {
+        return is_null($this->response) ? null : $this->response->getHeaders();
+    }
+
+    /**
+     * The Rest transport does not support trailing metadata. This is a
+     * passthrough to getMetadata().
+     */
+    public function getTrailingMetadata()
+    {
+        return $this->getMetadata();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPeer()
+    {
+        return $this->originalRequest->getUri();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function cancel()
+    {
+        if (!is_null($this->decoder)) {
+            $this->decoder->close();
+        }
+    }
+
+    /**
+     * For the REST transport this is a no-op.
+     */
+    public function setCallCredentials($call_credentials)
+    {
+        // Do nothing.
+    }
+}

--- a/tests/Tests/Unit/ApiExceptionTest.php
+++ b/tests/Tests/Unit/ApiExceptionTest.php
@@ -44,6 +44,9 @@ use Google\Rpc\RequestInfo;
 use Google\Rpc\ResourceInfo;
 use Google\Rpc\RetryInfo;
 use Google\Rpc\Status;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 
 class ApiExceptionTest extends TestCase
@@ -241,6 +244,47 @@ class ApiExceptionTest extends TestCase
                     ]
                 )
             ]
+        ];
+    }
+
+    /**
+     * @dataProvider buildRequestExceptions
+     */
+    public function testCreateFromRequestException($re, $stream, $expectedCode)
+    {
+        
+        $ae = ApiException::createFromRequestException($re, $stream);
+        $this->assertSame($expectedCode, $ae->getCode());
+    }
+
+    public function buildRequestExceptions()
+    { 
+        $error = [
+            'error' => [
+                'status' => 'NOT_FOUND',
+                'message' => 'Ruh-roh.',
+            ]
+        ];
+        $stream = RequestException::create(
+            new Request('POST', 'http://www.example.com'),
+            new Response(
+                404,
+                [],
+                json_encode([$error])
+            )
+        );
+        $unary = RequestException::create(
+            new Request('POST', 'http://www.example.com'),
+            new Response(
+                404,
+                [],
+                json_encode($error)
+            )
+        );
+        
+        return [
+            [$stream, true, Code::NOT_FOUND],
+            [$unary, false, Code::NOT_FOUND]
         ];
     }
 }

--- a/tests/Tests/Unit/Transport/Rest/JsonStreamDecoderTest.php
+++ b/tests/Tests/Unit/Transport/Rest/JsonStreamDecoderTest.php
@@ -32,6 +32,7 @@
 
 namespace Google\ApiCore\Tests\Unit\Transport\Rest;
 
+use Google\ApiCore\Testing\MockResponse;
 use Google\ApiCore\Tests\Unit\TestTrait;
 use Google\ApiCore\Transport\Rest\JsonStreamDecoder;
 use Google\LongRunning\Operation;
@@ -49,7 +50,8 @@ class JsonStreamDecoderTest extends TestCase
     /**
      * @dataProvider buildResponseStreams
      */
-    public function testJsonStreamDecoder(array $responses, $decodeType, $stream, $readChunkSizeBytes) {
+    public function testJsonStreamDecoder(array $responses, $decodeType, $stream, $readChunkSizeBytes)
+    {
         $decoder = new JsonStreamDecoder($stream, $decodeType, ['readChunkSizeBytes' => $readChunkSizeBytes]);
         $num = 0;
         foreach($decoder->decode() as $op) {
@@ -59,7 +61,8 @@ class JsonStreamDecoderTest extends TestCase
         $this->assertEquals(count($responses), $num);
     }
 
-    public function buildResponseStreams() {
+    public function buildResponseStreams()
+    {
         $any = new Any();
         $any->pack(new Operation([
             'name' => 'any_metadata',
@@ -120,7 +123,8 @@ class JsonStreamDecoderTest extends TestCase
         ];
     }
 
-    private function messagesToStream(array $messages) {
+    private function messagesToStream(array $messages)
+    {
         $data = [];
         foreach($messages as $message) {
             $data[] = $message->serializeToJsonString();
@@ -129,12 +133,45 @@ class JsonStreamDecoderTest extends TestCase
     }
 
     /**
-     * @dataProvider buildBadPayloads
-     * @expectedException \Exception
+     * @dataProvider buildAlternateStreams
      */
-    public function testJsonStreamDecoderBadClose($payload) {
-        $stream = new BufferStream();
-        $stream->write($payload);
+    public function testJsonStreamDecoderAlternate(array $responses, $decodeType, $stream)
+    {
+        $decoder = new JsonStreamDecoder($stream, $decodeType);
+        $num = 0;
+        foreach($decoder->decode() as $op) {
+            $this->assertEquals($responses[$num], $op);
+            $num++;
+        }
+        $this->assertEquals(count($responses), $num);
+    }
+
+    public function buildAlternateStreams()
+    {
+        $res1 = new MockResponse(['name' => 'foo']);
+        $res1Str = $res1->serializeToJsonString();
+        $res2 = new MockResponse(['name' => 'bar']);
+        $res2Str = $res2->serializeToJsonString();
+        $responses = [$res1, $res2];
+
+        $newlines = "[\n\n\n".$res1Str."\n\n\n,\n\n\n".$res2Str."\n\n\n]";
+        $commas = "[".$res1Str.",\n,\n,\n,".$res2Str."]";
+        $blankspace = "[".$res1Str.",           ".$res2Str."]";
+
+        return [
+            [$responses, MockResponse::class, $this->initBufferStream($newlines)],
+            [$responses, MockResponse::class, $this->initBufferStream($commas)],
+            [$responses, MockResponse::class, $this->initBufferStream($blankspace)]
+        ];
+    }
+
+    /**
+     * @dataProvider buildBadPayloads
+     * @expectedException \RuntimeException
+     */
+    public function testJsonStreamDecoderBadClose($payload)
+    {
+        $stream = $this->initBufferStream($payload);
         $decoder = new JsonStreamDecoder($stream, Operation::class, ['readChunkSizeBytes' => 10]);
         foreach($decoder->decode() as $op) {
             $this->assertSame('foo', $op->getName());
@@ -142,7 +179,8 @@ class JsonStreamDecoderTest extends TestCase
         }
     }
 
-    public function buildBadPayloads() {
+    public function buildBadPayloads()
+    {
         return
         [
             ['[{"name": "foo"},{'],
@@ -150,5 +188,27 @@ class JsonStreamDecoderTest extends TestCase
             ['[{"name": "foo"},{"name":'],
             ['[{"name": "foo"},{]'],
         ];
+    }
+
+    public function testJsonStreamDecoderClosed()
+    {
+        $stream = new BufferStream();
+        $stream->write('[{"name": "foo"},{');
+        $decoder = new JsonStreamDecoder($stream, Operation::class, ['readChunkSizeBytes' => 10]);
+        $count = 0;
+        foreach($decoder->decode() as $op) {
+            $this->assertEquals('foo', $op->getName());
+            $count++;
+            $decoder->close();
+        }
+
+        $this->assertEquals(1, $count);
+    }
+
+    private function initBufferStream($data)
+    {
+        $stream = new BufferStream();
+        $stream->write($data);
+        return $stream;
     }
 }

--- a/tests/Tests/Unit/Transport/RestTransportTest.php
+++ b/tests/Tests/Unit/Transport/RestTransportTest.php
@@ -32,6 +32,7 @@
 
 namespace Google\ApiCore\Tests\Unit\Transport;
 
+use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Call;
 use Google\ApiCore\RequestBuilder;
@@ -41,8 +42,10 @@ use Google\ApiCore\Testing\MockResponse;
 use Google\ApiCore\Transport\RestTransport;
 use Google\Auth\FetchAuthTokenInterface;
 use Google\Auth\HttpHandler\HttpHandlerFactory;
+use Google\Protobuf\Any;
+use Google\Rpc\ErrorInfo;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Promise;
+use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
@@ -95,7 +98,7 @@ class RestTransportTest extends TestCase
 
         $httpHandler = function (RequestInterface $request, array $options = []) use ($body, $expectedRequest) {
             $this->assertEquals($expectedRequest, $request);
-            return Promise\promise_for(
+            return Create::promiseFor(
                 new Response(
                     200,
                     [],
@@ -127,7 +130,7 @@ class RestTransportTest extends TestCase
     public function testStartUnaryCallThrowsException()
     {
         $httpHandler = function (RequestInterface $request, array $options = []) {
-            return Promise\rejection_for(new \Exception());
+            return Create::rejectionFor(new \Exception());
         };
 
         $this->getTransport($httpHandler)
@@ -141,7 +144,7 @@ class RestTransportTest extends TestCase
     public function testStartUnaryCallThrowsRequestException()
     {
         $httpHandler = function (RequestInterface $request, array $options = []) {
-            return Promise\rejection_for(
+            return Create::rejectionFor(
                 RequestException::create(
                     new Request('POST', 'http://www.example.com'),
                     new Response(
@@ -161,6 +164,143 @@ class RestTransportTest extends TestCase
         $this->getTransport($httpHandler)
             ->startUnaryCall($this->call, [])
             ->wait();
+    }
+    /**
+     * @dataProvider buildServerStreamMessages
+     */
+    public function testStartServerStreamingCall($messages)
+    {
+        $apiEndpoint = 'www.example.com';
+        $expectedRequest = new Request(
+            'POST',
+            $apiEndpoint,
+            [],
+            ""
+        );
+
+        $httpHandler = function (RequestInterface $request, array $options = []) use ($messages, $expectedRequest) {
+            $this->assertEquals($expectedRequest, $request);
+            return Create::promiseFor(
+                new Response(
+                    200,
+                    [],
+                    $this->encodeMessages($messages)
+                )
+            );
+        };
+
+        $stream = $this->getTransport($httpHandler, $apiEndpoint)
+            ->startServerStreamingCall($this->call, []);
+
+        $num = 0;
+        foreach($stream->readAll() as $m) {
+            $this->assertEquals($messages[$num], $m);
+            $num++;
+        }
+        $this->assertEquals(count($messages), $num);
+    }
+
+    /**
+     * @dataProvider buildServerStreamMessages
+     */
+    public function testCancelServerStreamingCall($messages)
+    {
+        $apiEndpoint = 'www.example.com';
+        $expectedRequest = new Request(
+            'POST',
+            $apiEndpoint,
+            [],
+            ""
+        );
+
+        $httpHandler = function (RequestInterface $request, array $options = []) use ($messages, $expectedRequest) {
+            $this->assertEquals($expectedRequest, $request);
+            return Create::promiseFor(
+                new Response(
+                    200,
+                    [],
+                    $this->encodeMessages($messages)
+                )
+            );
+        };
+
+        $stream = $this->getTransport($httpHandler, $apiEndpoint)
+            ->startServerStreamingCall($this->call, []);
+
+        $num = 0;
+        foreach($stream->readAll() as $m) {
+            $this->assertEquals($messages[$num], $m);
+            $num++;
+
+            // Intentionally cancel the stream mid way through processing.
+            $stream->getServerStreamingCall()->cancel();
+        }
+
+        // Ensure only one message was ever yielded.
+        $this->assertEquals(1, $num);
+    }
+
+    private function encodeMessages(array $messages) {
+        $data = [];
+        foreach($messages as $message) {
+            $data[] = $message->serializeToJsonString();
+        }
+        return '['.implode(',', $data).']';
+    }
+
+    public function buildServerStreamMessages() {
+        return[
+            [
+                [
+                    new MockResponse([
+                        'name' => 'foo',
+                        'number' => 1,
+                    ]),
+                    new MockResponse([
+                        'name' => 'bar',
+                        'number' => 2,
+                    ]),
+                    new MockResponse([
+                        'name' => 'baz',
+                        'number' => 3,
+                    ]),
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @expectedException \Google\ApiCore\ApiException
+     * @expectedExceptionCode 5
+     * @expectedExceptionMessage Ruh-roh.
+     */
+    public function testStartServerStreamingCallThrowsRequestException()
+    {
+        $apiEndpoint = 'http://www.example.com';
+        $errorInfo = new Any();
+        $errorInfo->pack(new ErrorInfo(['domain' => 'googleapis.com']));
+        $httpHandler = function (RequestInterface $request, array $options = []) use ($apiEndpoint, $errorInfo) {
+            return Create::rejectionFor(
+                RequestException::create(
+                    new Request('POST', $apiEndpoint),
+                    new Response(
+                        404,
+                        [],
+                        json_encode([[
+                            'error' => [
+                                'status' => 'NOT_FOUND',
+                                'message' => 'Ruh-roh.',
+                                'details' => [$errorInfo]
+                            ]
+                        ]])
+                    )
+                )
+            );
+        };
+
+        $this->getTransport($httpHandler, $apiEndpoint)
+            ->startServerStreamingCall($this->call, []);
+        
     }
 
     /**
@@ -264,7 +404,7 @@ class RestTransportTest extends TestCase
     public function testNonJsonResponseException()
     {
         $httpHandler = function (RequestInterface $request, array $options = []) {
-            return Promise\rejection_for(
+            return Create::rejectionFor(
                 RequestException::create(
                     new Request('POST', 'http://www.example.com'),
                     new Response(
@@ -294,7 +434,7 @@ class RestTransportTest extends TestCase
         ];
 
         $httpHandler = function (RequestInterface $request, array $options = []) {
-            return Promise\promise_for(new Response(200, [], '{}'));
+            return Create::promiseFor(new Response(200, [], '{}'));
         };
 
         $this->getTransport($httpHandler)


### PR DESCRIPTION
* feat: add REST server streaming support

* refactor & fix premature closing/cancelation

* refactor to Status

* set all fields of MockStatus in MockServerStreamingCall

* support streaming request exceptions

* check if index 0 exists in exception body

* skip newlines that break up items

* add more tests for weird streams

Co-authored-by: Lucas Michot <lmichot@gmail.com>
Co-authored-by: Brent Shaffer <betterbrent@google.com>